### PR TITLE
Progress bar with meaning

### DIFF
--- a/src/main/java/org/testshift/testcube/amplify/StartTestCubeAction.java
+++ b/src/main/java/org/testshift/testcube/amplify/StartTestCubeAction.java
@@ -26,6 +26,7 @@ import org.jetbrains.annotations.Nullable;
 import org.testshift.testcube.icons.TestCubeIcons;
 import org.testshift.testcube.inspect.InspectTestCubeResultsAction;
 import org.testshift.testcube.misc.Config;
+import org.testshift.testcube.misc.ProgressUpdater;
 import org.testshift.testcube.misc.TestCubeNotifier;
 import org.testshift.testcube.misc.Util;
 import org.testshift.testcube.settings.AppSettingsState;
@@ -137,7 +138,7 @@ public class StartTestCubeAction extends AnAction {
         String finalRelativePathToClasses = relativePathToClasses;
         String finalRelativePathToTestClasses = relativePathToTestClasses;
         String finalAutomaticBuilder = automaticBuilder;
-        Task.Backgroundable dspotTask = new Task.Backgroundable(currentProject, "Amplifying test", true) {
+        Task.Backgroundable dspotTask = new Task.Backgroundable(currentProject, "Running test-cube...", true) {
 
             public void run(@NotNull ProgressIndicator indicator) {
                 // clean output directory
@@ -218,12 +219,14 @@ public class StartTestCubeAction extends AnAction {
 
                     File dSpotTerminalOutput = new File(
                             Util.getTestCubeOutputPath(currentProject) + File.separator + "terminal_output_dspot.txt");
+                    ProgressUpdater progressUpdater = new ProgressUpdater(indicator);
 
                     try (BufferedWriter writer = new BufferedWriter(new FileWriter(dSpotTerminalOutput))) {
                         InputStream is = p.getInputStream();
                         BufferedReader br = new BufferedReader(new InputStreamReader(is));
                         for (String line = br.readLine(); line != null; line = br.readLine()) {
                             System.out.println(line);
+                            progressUpdater.onNewLine(line);
                             writer.write(line);
                             writer.newLine();
                         }

--- a/src/main/java/org/testshift/testcube/misc/ProgressUpdater.java
+++ b/src/main/java/org/testshift/testcube/misc/ProgressUpdater.java
@@ -1,0 +1,75 @@
+package org.testshift.testcube.misc;
+
+import com.intellij.openapi.progress.ProgressIndicator;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Reads test-cube's output to update progress indicator text.
+ */
+public class ProgressUpdater {
+    private final ProgressIndicator indicator;
+    private final Map<Pattern, PromptResolver> resolvers;
+
+    private static final Pattern BUILDING_PATTERN = Pattern.compile(".*run maven.*(\n)?");
+    private static final Pattern AMPLIFYING_PATTERN = Pattern.compile(
+            ".*Amplification of (.*) \\(\\d.* test\\(s\\)\\).*");
+
+    public ProgressUpdater(@NotNull ProgressIndicator indicator) {
+        this.indicator = indicator;
+        resolvers = new HashMap<>();
+        resolvers.put(BUILDING_PATTERN, new LiteralResolver("Building project..."));
+        resolvers.put(AMPLIFYING_PATTERN, new ExtractorResolver("Amplifying %s...", AMPLIFYING_PATTERN));
+    }
+
+    public void onNewLine(String line) {
+        resolvers.entrySet()
+                 .stream()
+                 .filter(entry -> entry.getKey().matcher(line).matches())
+                 .findFirst()
+                 .ifPresent(entry -> indicator.setText(entry.getValue().resolve(line)));
+    }
+
+    private interface PromptResolver {
+        String resolve(String line);
+    }
+
+    private static class LiteralResolver implements PromptResolver {
+        private final String literal;
+
+        LiteralResolver(String literal) {
+            this.literal = literal;
+        }
+
+        @Override
+        public String resolve(String line) {
+            return literal;
+        }
+    }
+
+    private static class ExtractorResolver implements PromptResolver {
+
+        private final Pattern pattern;
+        private final String format;
+
+        public ExtractorResolver(String format, Pattern pattern) {
+            this.format = format;
+            this.pattern = pattern;
+        }
+
+        @Override
+        public String resolve(String line) {
+            Matcher matcher = pattern.matcher(line);
+            boolean matches = matcher.matches();
+            if (!matches) {
+                throw new IllegalStateException("Invalid instance of " + ExtractorResolver.class);
+            }
+            return String.format(format, matcher.group(1));
+        }
+    }
+
+}


### PR DESCRIPTION
Implemented infrastructure to support progress bar updates by reading DSpot output (requested in #8).
I haven't been able to fully understand every stage of the amplification process by reading the logs, but surely someone with some experience with DSpot will be able to easily expand this work with customized progress messages.